### PR TITLE
Add peak_entity peak marker override

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub release](https://img.shields.io/github/release/cdelaet/sensor-bar-card-plus.svg)](https://github.com/cdelaet/sensor-bar-card-plus/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A modern sensor visualization card for Home Assistant dashboards, with dynamic min/max/target sources, flexible bar rendering, severity-aware coloring, target and peak markers, and compact information-dense layouts.
+A modern sensor visualization card for Home Assistant dashboards, with dynamic min/max/target/peak sources, flexible bar rendering, severity-aware coloring, target and peak markers, and compact information-dense layouts.
 
 It is built for dashboards where the visual context should follow live Home Assistant data instead of staying hardcoded. Sensor Bar Card Plus works well for power, temperature, humidity, battery, CO2, water flow, response times, quotas, and other numeric sensors, while still fitting cleanly into modern Lovelace layouts with smooth rendering and responsive label behavior.
 
@@ -15,7 +15,7 @@ It is built for dashboards where the visual context should follow live Home Assi
 
 ## Highlights
 
-- <img src="images/plus-rainbow-badge.svg" alt="PLUS" height="20"> **Dynamic min / max / target entities** for data-driven scales and references
+- <img src="images/plus-rainbow-badge.svg" alt="PLUS" height="20"> **Dynamic min / max / target / peak entities** for data-driven scales and references
 - 📈 **Target and peak markers** with optional target value labels
 - 🎨 **Severity gradient and severity-based coloring** with `gradient`, `severity`, `single`, and <img src="images/plus-rainbow-badge.svg" alt="PLUS" height="20"> `severity_gradient`
 - <img src="images/plus-rainbow-badge.svg" alt="PLUS" height="20"> **Above-target color** for visually separating the portion beyond a live or fixed threshold
@@ -298,11 +298,12 @@ The card supports:
 
 - fixed `target`
 - dynamic `target_entity`
+- dynamic `peak_entity`
 - optional `show_target_label`
 - optional `above_target_color`
 - optional `show_peak`
 
-The target marker sits on the bottom edge of the bar. The peak marker sits on the top edge. They coexist cleanly and can overlap at the same position without fighting for visibility.
+The target marker sits on the bottom edge of the bar. The peak marker sits on the top edge. They coexist cleanly and can overlap at the same position without fighting for visibility. By default, the peak marker tracks the highest value seen in the current browser session, but `peak_entity` can override that and drive the marker from another entity instead.
 
 ![Dynamic target and above-target color](images/above-target-small.gif)
 
@@ -347,6 +348,22 @@ entities:
     max: 3000
 ```
 
+### Dynamic `peak_entity`
+
+```yaml
+type: custom:sensor-bar-card-plus
+title: Peak Marker From Entity
+label_position: left
+show_peak: true
+peak_entity: sensor.caravan_peak_power
+entities:
+  - entity: sensor.caravan_power
+    name: Caravan
+    icon: mdi:caravan
+    min: 0
+    max: 3000
+```
+
 ### Target marker example
 
 ![Target marker](images/example-target.png)
@@ -369,15 +386,15 @@ entities:
 
 Peak and target markers can occupy the same position without becoming ambiguous because they live on opposite bar edges. That makes them suitable for shared-threshold visualizations and future multi-reference extensions.
 
-## Dynamic Min / Max / Target Entities
+## Dynamic Min / Max / Target / Peak Entities
 
 <img src="images/plus-rainbow-badge.svg" alt="PLUS" height="20">
 
-You can source `min`, `max`, and `target` from other entities instead of hardcoding them in the card config.
+You can source `min`, `max`, `target`, and `peak` from other entities instead of hardcoding them in the card config.
 
 This is especially useful when the scale and threshold are driven by other helpers, automations, or template sensors.
 
-Why dynamic sources matter: the card can follow real Home Assistant entities for scale and target context instead of baking those values into YAML. That makes the visualization adapt naturally to batteries, grid limits, quotas, thresholds, changing operating modes, and dashboards where the meaning of "full", "safe", or "on target" changes over time.
+Why dynamic sources matter: the card can follow real Home Assistant entities for scale and reference context instead of baking those values into YAML. That makes the visualization adapt naturally to batteries, grid limits, quotas, thresholds, changing operating modes, dashboards where the meaning of "full", "safe", or "on target" changes over time, and sensors that already publish their own rolling or billing-period peak.
 
 ![Dynamic min and max entities](images/example-dynamic-min-max-entity.png)
 
@@ -613,6 +630,7 @@ All options can be set globally at card level and overridden per entity.
 | `severity` | list | built-in default | Used by `severity` and `severity_gradient` | - |
 | `animated` | boolean | `true` | Animate value changes | - |
 | `show_peak` | boolean | `false` | Show peak marker | - |
+| `peak_entity` | string | - | Dynamic peak value entity, overrides live peak tracking | <img src="images/plus-rainbow-badge.svg" alt="PLUS" height="20"> |
 | `peak_color` | string | `#888` | Peak marker color | - |
 | `target` | number | - | Fixed target value | - |
 | `target_entity` | string | - | Dynamic target value entity | <img src="images/plus-rainbow-badge.svg" alt="PLUS" height="20"> |
@@ -641,7 +659,7 @@ Each entry in `entities` accepts the card-level options above plus:
 ## Behavior Notes
 
 - Clicking a row opens the native Home Assistant more-info dialog.
-- Peak values are stored in memory and reset when the page reloads.
+- Peak values are stored in memory and reset when the page reloads, unless `peak_entity` is configured.
 - Textual states do not show leftover units.
 - Time units `h`, `m`, and `s` render tight, for example `43s` and `4h`.
 - Responsive fallbacks preserve readability instead of letting labels and values collide.
@@ -670,7 +688,7 @@ Compared to the original card, Sensor Bar Card Plus adds or reworks:
 
 - layout refactor for consistent bar alignment and more truthful row geometry
 - responsive label/value fallback behavior during resize, zoom, and cramped widths
-- dynamic `min_entity`, `max_entity`, and `target_entity`
+- dynamic `min_entity`, `max_entity`, `target_entity`, and `peak_entity`
 - target marker, target value label, and above-target color highlighting
 - synchronized target animation so marker, label, and above-target split move together
 - `severity_gradient` as a separate color mode, alongside proper fixed-band `severity`

--- a/dist/sensor-bar-card-plus.js
+++ b/dist/sensor-bar-card-plus.js
@@ -17,6 +17,7 @@
  *   color: '#4a9eff'              # bar colour when color_mode is 'single'
  *   animated: true                # smooth bar fill transition on value change
  *   show_peak: true               # show peak marker (highest value seen this session)
+ *   peak_entity: sensor.my_peak_sensor       # optional entity providing the peak marker value
  *   peak_color: '#888'             # colour of the peak marker (default grey)
  *   target: 2400                   # optional fixed target marker (absolute value, same scale as min/max)
  *   target_entity: sensor.my_target_sensor   # optional entity providing the target marker value
@@ -59,6 +60,7 @@
  *       above_target_color: '#F44336'
  *       animated: true
  *       show_peak: true
+ *       peak_entity: sensor.my_peak_sensor
  *       severity:
  *         - from: 0
  *           to: 50
@@ -143,6 +145,7 @@ class SensorBarCard extends HTMLElement {
       color: '#4a9eff',
       animated: true,
       show_peak: false,
+      peak_entity: null,
       peak_color: '#888',
       target: null,
       target_entity: null,
@@ -206,6 +209,7 @@ class SensorBarCard extends HTMLElement {
       color:          entityCfg.color          ?? g.color,
       severity:       entityCfg.severity       ?? g.severity,
       show_peak:      entityCfg.show_peak      ?? g.show_peak,
+      peak_entity:    entityCfg.peak_entity    ?? g.peak_entity ?? null,
       peak_color:     entityCfg.peak_color     ?? g.peak_color,
       target:         entityCfg.target         ?? g.target,
       target_entity:  entityCfg.target_entity  ?? g.target_entity ?? null,
@@ -230,6 +234,7 @@ class SensorBarCard extends HTMLElement {
         entityCfg.entity,
         ecfg.min_entity,
         ecfg.max_entity,
+        ecfg.peak_entity,
         ecfg.target_entity
       ].filter(Boolean);
       
@@ -300,6 +305,16 @@ class SensorBarCard extends HTMLElement {
     
     const num = parseFloat(value);
     return Number.isFinite(num) ? num : null;
+  }
+
+  _getPeakValue(entityId, rawVal, peakEntityId = null) {
+    if (peakEntityId) return this._getEntityNumericValue(peakEntityId);
+    if (!Number.isFinite(rawVal)) return null;
+
+    if (this._peaks[entityId] === undefined || rawVal > this._peaks[entityId]) {
+      this._peaks[entityId] = rawVal;
+    }
+    return this._peaks[entityId];
   }
 
   _hexToRgb(color) {
@@ -1306,8 +1321,8 @@ class SensorBarCard extends HTMLElement {
     const targetContrastColor = this._getMarkerContrastColor(targetMarkerColor);
 
     // Peak marker — chevron top, line full height, configurable colour
-    const peakMarker = ecfg.show_peak && peakPct !== null ? `
-      <div class="peak-marker" style="left:${peakPct}%;--marker-color:${peakMarkerColor};--marker-contrast-color:${peakContrastColor};">
+    const peakMarker = ecfg.show_peak ? `
+      <div class="peak-marker" style="left:${peakPct !== null ? peakPct : 0}%;--marker-color:${peakMarkerColor};--marker-contrast-color:${peakContrastColor};display:${peakPct !== null ? '' : 'none'};">
         <div class="peak-outset"></div>
         <div class="peak-inset"></div>
       </div>` : '';
@@ -1410,10 +1425,14 @@ class SensorBarCard extends HTMLElement {
           targetDisplay = this._formatDisplayWithUnit(targetVal.toLocaleString(), unit);
         }
         let peakPct = null, peakDisplay = null;
-        if (ecfg.show_peak && !isNaN(rawVal)) {
-          this._peaks[entityCfg.entity] = rawVal;
-          peakPct     = pct;
-          peakDisplay = display;
+        const peakVal = ecfg.show_peak
+          ? this._getPeakValue(entityCfg.entity, rawVal, ecfg.peak_entity)
+          : null;
+        if (peakVal !== null) {
+          peakPct = Math.min(100, Math.max(0, ((peakVal - safeMin) / range) * 100));
+          peakDisplay = ecfg.decimal !== null
+            ? parseFloat(peakVal.toFixed(ecfg.decimal)).toLocaleString()
+            : peakVal.toLocaleString();
         }
         html += this._buildRow(entityCfg, display, displayUnit, pct, color, peakPct, peakDisplay, targetPct, targetDisplay, ecfg.peak_color, ecfg.target_color);
       }
@@ -1499,15 +1518,18 @@ class SensorBarCard extends HTMLElement {
       }
 
       // Update peak marker position
-      if (ecfg.show_peak && !isNaN(rawVal)) {
-        const key = entityCfg.entity;
-        if (this._peaks[key] === undefined || rawVal > this._peaks[key]) {
-          this._peaks[key] = rawVal;
-        }
-        const peakVal = this._peaks[key];
-        const peakPct = Math.min(100, Math.max(0, ((peakVal - safeMin) / range) * 100));
+      if (ecfg.show_peak) {
+        const peakVal = this._getPeakValue(entityCfg.entity, rawVal, ecfg.peak_entity);
         const peakEl  = row.querySelector('.peak-marker');
-        if (peakEl) peakEl.style.left = `${peakPct}%`;
+        if (peakEl) {
+          if (peakVal !== null) {
+            const peakPct = Math.min(100, Math.max(0, ((peakVal - safeMin) / range) * 100));
+            peakEl.style.display = '';
+            peakEl.style.left = `${peakPct}%`;
+          } else {
+            peakEl.style.display = 'none';
+          }
+        }
       }
       // Update target marker position (for dynamic target_entity)
       if (targetVal !== null) {


### PR DESCRIPTION
This allows the peak value to come from an entity defined in `peak_entity` as proposed in #2.

This closes #2.