### PR TITLE
Round Target Marker display value to the correct decimal format

### DIFF
--- a/src/sensor-bar-card-plus.js
+++ b/src/sensor-bar-card-plus.js
@@ -3283,7 +3283,8 @@ ${paintLayers}
       }
 
       if (targetLabelEl) {
-        this._setTextIfChanged(targetLabelEl, this._formatDisplayWithUnit(targetVal.toLocaleString(), unit));
+        // Round the Target Value displayed to correct decimal format
+        this._setTextIfChanged(targetLabelEl, this._formatDisplayWithUnit(this._formatNumericDisplay(targetVal, ecfg.formatting.decimal), unit));		  
       }
     } else {
       if (targetEl) this._setStyleIfChanged(targetEl, 'display', 'none');
@@ -3332,7 +3333,8 @@ ${paintLayers}
         }
         let targetDisplay = null;
         if (targetVal !== null) {
-          targetDisplay = this._formatDisplayWithUnit(targetVal.toLocaleString(), unit);
+          // Round the Target Value displayed to correct decimal format                   
+          targetDisplay = this._formatDisplayWithUnit(this._formatNumericDisplay(targetVal, ecfg.formatting.decimal), unit);			
         }
         let peakPct = null, peakDisplay = null;
         if (ecfg.peak_marker.show && !isNaN(rawVal)) {


### PR DESCRIPTION
Target Marker value displayed was shown raw, without using the decimal format